### PR TITLE
added support to work on windows using the bash from the linux subsys…

### DIFF
--- a/src/main/kotlin/com/elpassion/mainframerplugin/common/console/commandLineProvider.kt
+++ b/src/main/kotlin/com/elpassion/mainframerplugin/common/console/commandLineProvider.kt
@@ -4,11 +4,26 @@ import com.elpassion.mainframerplugin.common.StateProvider
 import com.elpassion.mainframerplugin.task.TaskData
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
+import java.util.stream.Collectors
 
 val commandLineProvider: (Project, TaskData) -> GeneralCommandLine = { project, taskData ->
     with(taskData) {
         if (StateProvider.getInstance(project).isTurnOn) {
-            GeneralCommandLine("bash", mainframerPath, buildCommand)
+
+            // bash command cannot work with Windows paths so converting to ie c:\ to /mnt/c/ for linux subsystem
+            // TODO figure out a way to work with cygwin on windows as well (/cygdrive/c/)
+            var modifiedMainframerPath = mainframerPath
+            // If windows OS and path starts with Character + Colon, then converting
+            if (System.getProperty("os.name").contains("Windows") && mainframerPath.contains("^.:".toRegex())) {
+                modifiedMainframerPath = "/mnt/" +
+                        // removing the initial colon, changing the drive letter to lower case,
+                        // and changing all backslashes to forward slashes
+                        mainframerPath.replaceFirst("^.:".toRegex(), mainframerPath[0].toLowerCase().toString())
+                                .split("\\\\".toRegex()).stream()
+                                .map(String::toString).collect(Collectors.joining("/"))
+            }
+
+            GeneralCommandLine("bash", modifiedMainframerPath, buildCommand)
         } else {
             GeneralCommandLine("bash", "-c", buildCommand)
         }


### PR DESCRIPTION
Seems like this plugin only works on linux / mac.  Not entirely sure I wrote the code in the correct place, really not a kotlin or intellij developer but this works for me to be able to run the plugin on windows.